### PR TITLE
New folder structure support

### DIFF
--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -58,7 +58,7 @@ def gen_url(ip, branch, folder, filename, url_template):
 
 
 class downloader(utils):
-    def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None):
+    def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None, reference_boot_folder=None):
         self.http_server_ip = http_server_ip
         self.update_defaults_from_yaml(
             yamlfilename, __class__.__name__, board_name=board_name
@@ -137,7 +137,7 @@ class downloader(utils):
         self.download(url, filename)
 
     def _get_files(
-        self, design_name, details, source, source_root, branch, firmware=False
+        self, design_name, dtb_folder, details, source, source_root, branch, firmware=False
     ):
         kernel = False
         kernel_root = False
@@ -180,21 +180,27 @@ class downloader(utils):
             # Get kernel
             print("Get", kernel)
             self._get_file(kernel, source, kernel_root, source_root, branch)
+            
             # Get BOOT.BIN
             print("Get BOOT.BIN")
+
             self._get_file("BOOT.BIN", source, design_source_root, source_root, branch)
-            # Get device tree
-            print("Get", dt)
-            self._get_file(dt, source, design_source_root, source_root, branch)
+            
             # Get support files (bootgen_sysfiles.tgz)
             print("Get support")
             self._get_file(
                 "bootgen_sysfiles.tgz", source, design_source_root, source_root, branch
             )
+            # Get device tree
+            print("Get", dt)
+            if dtb_folder!=design_name:
+                design_source_root = design_name+ '/' +dtb_folder
+            self._get_file(dt, source, design_source_root, source_root, branch)
 
     def download_boot_files(
         self,
         design_name,
+        dtb_folder='',
         source="local_fs",
         source_root="/var/lib/tftpboot",
         branch="master",
@@ -206,6 +212,7 @@ class downloader(utils):
 
             Parameters:
                 design_name: Target design name (same as boot file folder on SD card)
+                dtb_folder: Applicable to target design name with sub-folder for devicetree (name of sub-folder)
                 source: Source location type. Options: local_fs, http, artifactory
                 source_root: Root location of files. Dependent on source parameter
                     For local_fs this is a system path
@@ -227,6 +234,7 @@ class downloader(utils):
 
         self._get_files(
             design_name,
+            dtb_folder,
             board_configs[design_name],
             source,
             source_root,

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -157,7 +157,7 @@ class manager:
                 self.driver.uri = "ip:" + ip
                 # Update config file
                 self.help.update_yaml(
-                    self.configfilename, "network-config", "dutip", ip
+                    self.configfilename, "network-config", "dutip", ip, self.board_name
                 )
 
             # Update board over SSH and reboot
@@ -211,7 +211,11 @@ class manager:
                 else:
                     # Update config file
                     self.help.update_yaml(
-                        self.configfilename, "network-config", "dutip", ip
+                        self.configfilename,
+                        "network-config",
+                        "dutip",
+                        ip,
+                        self.board_name,
                     )
 
         # Check SSH
@@ -241,7 +245,11 @@ class manager:
                     self.driver.uri = "ip:" + ip
                     # Update config file
                     self.help.update_yaml(
-                        self.configfilename, "network-config", "dutip", ip
+                        self.configfilename,
+                        "network-config",
+                        "dutip",
+                        ip,
+                        self.board_name,
                     )
                 self.net.check_board_booted()
             except Exception as ex:

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -79,6 +79,7 @@ class manager:
 
         self.help = helper.helper()
         self.usbdev = usbdev()
+        self.board_name = board_name
 
     def get_status(self):
         pass

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -52,18 +52,15 @@ zynq-adrv9364-z7020-packrf:
   carrier: ADRV1CRR-BOX
 zynq-zc702-adv7511:
   carrier: ZC702
-zynq-zc702-adv7511-ad9361-fmcomms2-3:
+zynq-zc702-adv7511-ad9361-fmcomms2-3-4:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
+  - AD-FMCOMMS4-EBZ
   carrier: ZC702
 zynq-zc702-adv7511-ad9361-fmcomms5:
   addons:
   - AD-FMCOMMS5-EBZ
-  carrier: ZC702
-zynq-zc702-adv7511-ad9364-fmcomms4:
-  addons:
-  - AD-FMCOMMS4-EBZ
   carrier: ZC702
 zynq-zc706-adv7511:
   carrier: ZC706
@@ -79,10 +76,11 @@ zynq-zc706-adv7511-ad9265-fmc-125ebz:
   addons:
   - AD9265-FMC-125EBZ
   carrier: ZC706
-zynq-zc706-adv7511-ad9361-fmcomms2-3:
+zynq-zc706-adv7511-ad9361-fmcomms2-3-4:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
+  - AD-FMCOMMS4-EBZ
   carrier: ZC706
 zynq-zc706-adv7511-ad9361-fmcomms5:
   addons:
@@ -91,10 +89,6 @@ zynq-zc706-adv7511-ad9361-fmcomms5:
 zynq-zc706-adv7511-ad9361-fmcomms5-ext-lo-adf5355:
   addons:
   - AD-FMCOMMS5-EBZ external LO
-  carrier: ZC706
-zynq-zc706-adv7511-ad9364-fmcomms4:
-  addons:
-  - AD-FMCOMMS4-EBZ
   carrier: ZC706
 zynq-zc706-adv7511-ad9434-fmc-500ebz:
   addons:
@@ -112,11 +106,7 @@ zynq-zc706-adv7511-ad9739a-fmc:
   addons:
   - EVAL-AD9739A
   carrier: ZC706
-zynq-zc706-adv7511-adrv9008-1:
-  addons:
-  - EVAL-ADRV9008-9009
-  carrier: ZC706
-zynq-zc706-adv7511-adrv9008-2:
+zynq-zc706-adv7511-adrv9008-1-2:
   addons:
   - EVAL-ADRV9008-9009
   carrier: ZC706
@@ -154,13 +144,10 @@ zynq-zc706-adv7511-fmcomms11:
   carrier: ZC706
 zynq-zed-adv7511:
   carrier: Zed-Board
-zynq-zed-adv7511-ad9361-fmcomms2-3:
+zynq-zed-adv7511-ad9361-fmcomms2-3-4:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
-  carrier: Zed-Board
-zynq-zed-adv7511-ad9364-fmcomms4:
-  addons:
   - AD-FMCOMMS4-EBZ
   carrier: Zed-Board
 zynq-zed-adv7511-ad9467-fmc-250ebz:
@@ -183,28 +170,21 @@ zynqmp-zcu102-rev10-ad9172-fmc-ebz-mode4:
   addons:
   - EVAL-AD9172
   carrier: ZCU102
-zynqmp-zcu102-rev10-ad9361-fmcomms2-3:
+zynqmp-zcu102-rev10-ad9361-fmcomms2-3-4:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
+  - AD-FMCOMMS4-EBZ
   carrier: ZCU102
 zynqmp-zcu102-rev10-ad9361-fmcomms5:
   addons:
   - AD-FMCOMMS5-EBZ
   carrier: ZCU102
-zynqmp-zcu102-rev10-ad9364-fmcomms4:
-  addons:
-  - AD-FMCOMMS4-EBZ
-  carrier: ZCU102
 zynqmp-zcu102-rev10-adrv9002:
   addons:
   - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
   carrier: ZCU102
-zynqmp-zcu102-rev10-adrv9008-1:
-  addons:
-  - EVAL-ADRV9008-9009
-  carrier: ZCU102
-zynqmp-zcu102-rev10-adrv9008-2:
+zynqmp-zcu102-rev10-adrv9008-1-2:
   addons:
   - EVAL-ADRV9008-9009
   carrier: ZCU102

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -52,15 +52,18 @@ zynq-adrv9364-z7020-packrf:
   carrier: ADRV1CRR-BOX
 zynq-zc702-adv7511:
   carrier: ZC702
-zynq-zc702-adv7511-ad9361-fmcomms2-3-4:
+zynq-zc702-adv7511-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
-  - AD-FMCOMMS4-EBZ
   carrier: ZC702
 zynq-zc702-adv7511-ad9361-fmcomms5:
   addons:
   - AD-FMCOMMS5-EBZ
+  carrier: ZC702
+zynq-zc702-adv7511-ad9364-fmcomms4:
+  addons:
+  - AD-FMCOMMS4-EBZ
   carrier: ZC702
 zynq-zc706-adv7511:
   carrier: ZC706
@@ -76,11 +79,10 @@ zynq-zc706-adv7511-ad9265-fmc-125ebz:
   addons:
   - AD9265-FMC-125EBZ
   carrier: ZC706
-zynq-zc706-adv7511-ad9361-fmcomms2-3-4:
+zynq-zc706-adv7511-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
-  - AD-FMCOMMS4-EBZ
   carrier: ZC706
 zynq-zc706-adv7511-ad9361-fmcomms5:
   addons:
@@ -89,6 +91,10 @@ zynq-zc706-adv7511-ad9361-fmcomms5:
 zynq-zc706-adv7511-ad9361-fmcomms5-ext-lo-adf5355:
   addons:
   - AD-FMCOMMS5-EBZ external LO
+  carrier: ZC706
+zynq-zc706-adv7511-ad9364-fmcomms4:
+  addons:
+  - AD-FMCOMMS4-EBZ
   carrier: ZC706
 zynq-zc706-adv7511-ad9434-fmc-500ebz:
   addons:
@@ -106,7 +112,11 @@ zynq-zc706-adv7511-ad9739a-fmc:
   addons:
   - EVAL-AD9739A
   carrier: ZC706
-zynq-zc706-adv7511-adrv9008-1-2:
+zynq-zc706-adv7511-adrv9008-1:
+  addons:
+  - EVAL-ADRV9008-9009
+  carrier: ZC706
+zynq-zc706-adv7511-adrv9008-2:
   addons:
   - EVAL-ADRV9008-9009
   carrier: ZC706
@@ -144,10 +154,13 @@ zynq-zc706-adv7511-fmcomms11:
   carrier: ZC706
 zynq-zed-adv7511:
   carrier: Zed-Board
-zynq-zed-adv7511-ad9361-fmcomms2-3-4:
+zynq-zed-adv7511-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
+  carrier: Zed-Board
+zynq-zed-adv7511-ad9364-fmcomms4:
+  addons:
   - AD-FMCOMMS4-EBZ
   carrier: Zed-Board
 zynq-zed-adv7511-ad9467-fmc-250ebz:
@@ -170,21 +183,28 @@ zynqmp-zcu102-rev10-ad9172-fmc-ebz-mode4:
   addons:
   - EVAL-AD9172
   carrier: ZCU102
-zynqmp-zcu102-rev10-ad9361-fmcomms2-3-4:
+zynqmp-zcu102-rev10-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ
   - AD-FMCOMMS3-EBZ
-  - AD-FMCOMMS4-EBZ
   carrier: ZCU102
 zynqmp-zcu102-rev10-ad9361-fmcomms5:
   addons:
   - AD-FMCOMMS5-EBZ
   carrier: ZCU102
+zynqmp-zcu102-rev10-ad9364-fmcomms4:
+  addons:
+  - AD-FMCOMMS4-EBZ
+  carrier: ZCU102
 zynqmp-zcu102-rev10-adrv9002:
   addons:
   - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
   carrier: ZCU102
-zynqmp-zcu102-rev10-adrv9008-1-2:
+zynqmp-zcu102-rev10-adrv9008-1:
+  addons:
+  - EVAL-ADRV9008-9009
+  carrier: ZCU102
+zynqmp-zcu102-rev10-adrv9008-2:
   addons:
   - EVAL-ADRV9008-9009
   carrier: ZCU102

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -12,13 +12,13 @@
 board-config:
   field_1:
     name: board-name
-    default: zynq-zc706-adv7511-fmcdaq2
-    help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD"
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3
+    help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
   field_2:
     name: reference-boot-folder
-    default: zynq-zc706-adv7511-fmcdaq2
-    help: "Folder name where reference boot files exit for specific board"
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3-4
+    help: "Folder name where reference boot files exist for specific board. \nThis is the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
   field_3:
     name: monitoring-interface

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -15,18 +15,13 @@ board-config:
     default: zynq-zc702-adv7511-ad9361-fmcomms2-3
     help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
-  field_2:
-    name: reference-boot-folder
-    default: zynq-zc702-adv7511-ad9361-fmcomms2-3-4
-    help: "Folder name where reference boot files exist for specific board. \nThis is the same as the boot folder name of the AD-FMC-SDCARD."
-    optional: False
-  field_3:
+  field_4:
     name: monitoring-interface
     default: uart
     help: "Select monitoring interface"
     options: [uart, netconsole]
     optional: False
-  field_4:
+  field_5:
     name: allow-jtag
     default: False
     help: "Allow use of JTAG"
@@ -124,6 +119,21 @@ downloader-config:
     default: 192.168.2.1
     help: "IP address of build server with boot files"
     optional: True
+  field_2:
+    name: reference-boot-folder
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3-4
+    help: "Folder name where reference boot files exist for specific board. \nThis is the same as the boot folder name of the AD-FMC-SDCARD."
+    optional: False
+  field_3:
+    name: devicetree-subfolder
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3
+    help: "Subfolder name where devicetree files exists for specific boards.""
+    optional: False
+  field_4:
+    name: boot-subfolder
+    default: boot_bin_CMOS
+    help: "Subfolder name where boot files exist for specific boards."
+    optional: False
 jtag-config:
   field_1:
     name: vivado_version

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -125,7 +125,6 @@ def download_sdcard(c, release="2019_R1"):
 @task(
     help={
         "board_name": "Board configuration name. Ex: zynq-zc702-adv7511-ad9361-fmcomms2-3",
-        "reference_boot_folder": "Folder name where reference boot files exist for specific board. Ex: zynq-zc702-adv7511-ad9361-fmcomms2-3-4",
         "source": "Boot file download source. Options are: local_fs, http, artifactory, remote.\nDefault: local_fs",
         "source_root": "Location of source boot files. Dependent on source.\nFor http sources this is a IP or domain name (no http://)",
         "branch": "Name of branch to get related files. This is only used for\bhttp and artifactory sources. Default is master",
@@ -140,12 +139,11 @@ def download_boot_files(
     branch="master",
     yamlfilename="/etc/default/nebula",
     board_name=None,
-    reference_boot_folder=None,
     firmware=False,
 ):
     """ Download bootfiles for a specific development system """
-    d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name, reference_boot_folder=reference_boot_folder)
-    d.download_boot_files(reference_boot_folder, board_name,  source, source_root, branch)
+    d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
+    d.download_boot_files(board_name,  source, source_root, branch)
 
 
 dl = Collection("dl")

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -124,7 +124,8 @@ def download_sdcard(c, release="2019_R1"):
 
 @task(
     help={
-        "board_name": "Board configuration name. Ex: zynqmp-zcu102-rev10-adrv9371",
+        "board_name": "Board configuration name. Ex: zynq-zc702-adv7511-ad9361-fmcomms2-3",
+        "reference_boot_folder": "Folder name where reference boot files exist for specific board. Ex: zynq-zc702-adv7511-ad9361-fmcomms2-3-4",
         "source": "Boot file download source. Options are: local_fs, http, artifactory, remote.\nDefault: local_fs",
         "source_root": "Location of source boot files. Dependent on source.\nFor http sources this is a IP or domain name (no http://)",
         "branch": "Name of branch to get related files. This is only used for\bhttp and artifactory sources. Default is master",
@@ -139,11 +140,12 @@ def download_boot_files(
     branch="master",
     yamlfilename="/etc/default/nebula",
     board_name=None,
+    reference_boot_folder=None,
     firmware=False,
 ):
     """ Download bootfiles for a specific development system """
-    d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
-    d.download_boot_files(board_name, source, source_root, branch)
+    d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name, reference_boot_folder=reference_boot_folder)
+    d.download_boot_files(reference_boot_folder, board_name,  source, source_root, branch)
 
 
 dl = Collection("dl")


### PR DESCRIPTION
Added support for new folder structure. The reference boot folder, devicetree subfolder, and boot subfolder should be declared in the nebula config file under downloader-config.